### PR TITLE
"Last Commit ID" gets updated before Applying Latest Content

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -18,6 +18,7 @@ Copyright end */
     $scope.parent_wf_id = '';
     var subscription;
     const playbookIRI = '24963415-4057-4fd5-bbe5-bf7d6bfa059d';
+    const updatePlaybookIRI = 'de8a2184-a9f0-4530-ace7-132247f2be31';
 
     $scope.$on('websocket:reconnect', function () {
       initWebsocket();
@@ -52,12 +53,6 @@ Copyright end */
       var endpoint = API.WORKFLOW + 'api/workflows/' + $scope.parent_wf_id + '/';
       $http.get(endpoint).then(function (response) {
         if (response.data.status === 'finished') {
-          if (subscription) {
-            websocketService.unsubscribe(subscription);
-          }
-          $scope.selectedRepository = null;
-          $scope.isTemplateSelected = false;
-          $scope.isPlaybookExecuted = false;
           if (!CommonUtils.isUndefined(response.data.result.data) && response.data.result.data.status == "Reviewing") {
             _openWizard(response.data.result.data.uuid);
           }
@@ -66,6 +61,9 @@ Copyright end */
               toaster.warning({
                 body: "Reset the \"Apply Latest Content\" task and try again."
               });
+              $scope.selectedRepository = null;
+              $scope.isTemplateSelected = false;
+              $scope.isPlaybookExecuted = false;
               $scope.isToaster = true;
               websocketService.unsubscribe(subscription);
             }
@@ -136,6 +134,28 @@ Copyright end */
       });
       modal.result.finally(function () {
         $scope.$broadcast('csGrid:refresh', 500);
+        var endpoint = API.BASE + 'import_jobs/' + jobUuid + '?__selectFields=errorMessage,status,progressPercent,file,currentlyImporting,options';
+        $http.get(endpoint).then(function (response) {
+          if (response.data.currentlyImporting !== 'completed') {
+            toaster.warning({
+              body: "Failed to complete the \"Review and Apply Latest Content\" operation."
+            });
+          }
+          var queryPayload = {
+            "request": {
+              "selectedRepository": $scope.selectedRepository,
+              "record": (FormEntityService.get()).originalData,
+              "importStatus": response.data.currentlyImporting
+            }
+          };
+          var queryUrl = API.MANUAL_TRIGGER + updatePlaybookIRI;
+          $http.post(queryUrl, queryPayload).then(function (response) {
+            $scope.pullLatestContentPlaybookTaskID = response.data.task_id;
+          });
+          $scope.selectedRepository = null;
+          $scope.isTemplateSelected = false;
+          $scope.isPlaybookExecuted = false;
+        });
       });
     }
 

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -57,7 +57,7 @@ Copyright end */
             _openWizard(response.data.result.data.uuid);
           }
           else {
-            if (!$scope.isToaster) {
+            if (!$scope.isToaster && !CommonUtils.isUndefined(response.data.result.data)) {
               toaster.warning({
                 body: "Reset the \"Apply Latest Content\" task and try again."
               });


### PR DESCRIPTION
#### PMDB: https://pmdb.fortinet.com/ProjectManagement/project/detail/38282

- 1205648  | The "Last Commit ID" was being updated before the "Apply Latest Content" operation was actually performed.
    - `Root Cause (RCA)`: It was not possible to determine whether the import template status was Completed or not.
    - `Solution`: 
       - The callback is now handled within the modal.result.finally block, ensuring it executes after the import wizard finishes—regardless of success or failure.
       - Using the export job UUID, the system checks if the corresponding import job has completed. Based on this status, details are passed to the playbook.
       - The playbook then updates the Commit ID and Commit Status accordingly.
       - `Playbook Changes`:
          - Updated: Review and Apply Latest Content playbook — removed logic for updating Commit ID and Commit Status.
          - Newly Added: Update Apply Latest Content Commit Details playbook — handles updating of Commit ID and Commit Status based on the import job’s completion status.