### PR TITLE
Fixed Bug: 1208866

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -56,6 +56,16 @@ Copyright end */
           if (!CommonUtils.isUndefined(response.data.result.data) && response.data.result.data.status == "Reviewing") {
             _openWizard(response.data.result.data.uuid);
           }
+          else if (!CommonUtils.isUndefined(response.data.result.data) && response.data.result.data.status == "Connector or User Mapping Missing") {
+            toaster.warning({
+              body: "The logged-in user does not have a configured source control connector or is not mapped to a source control username."
+            });
+            $scope.selectedRepository = null;
+            $scope.isTemplateSelected = false;
+            $scope.isPlaybookExecuted = false;
+            $scope.isToaster = true;
+            websocketService.unsubscribe(subscription);
+          }
           else {
             if (!$scope.isToaster && !CommonUtils.isUndefined(response.data.result.data)) {
               toaster.warning({


### PR DESCRIPTION
- **1208866 | "Review & Apply Latest Content" button keeps loading when the FSR user is not mapped to a source control user.**  
  - **Root Cause:**  
    If the FSR user lacks the Connector configuration or User Mapping, they do not have permission to perform the "Apply Latest Content" operation. As a result, the playbook terminates without executing source control actions. This scenario was not previously handled by the widget.  
  - **Solution:**  
    - Added a `Return Response` step in the `Review and Apply Latest Content` playbook to set a variable that returns the status "Connector or User Mapping Missing" if the logged-in FSR user is unmapped or missing connector configuration.  
    - Updated the widget to check for this status; if detected, it displays a toaster notification and stops the loading spinner.
